### PR TITLE
CirclePageIndicator bug

### DIFF
--- a/Com.ViewPagerIndicator/CirclePageIndicator.cs
+++ b/Com.ViewPagerIndicator/CirclePageIndicator.cs
@@ -319,7 +319,6 @@ namespace Com.ViewPagerIndicator
 			if (mSnap || mScrollState == ViewPager.ScrollStateIdle)
 			{
 				mCurrentPage = position;
-				mSnapPage = position;
 				Invalidate();
 			}
 


### PR DESCRIPTION
mSnapPage is an exposed property, which users are supposed to set.
You're resetting this value in OnPageSelected(int position)... to position, which is completely undesirable & unexpected for people who have set it some value in their code.
They want to see the selected dot to be, what they have chosen for mSnapPage[not the position]